### PR TITLE
[Fixes #5] Override getActionUpdateThread() to return non-deprecated ActionUpdateThread value

### DIFF
--- a/src/DuplicateLines.java
+++ b/src/DuplicateLines.java
@@ -1,4 +1,5 @@
 import com.intellij.codeInsight.hint.HintManager;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -57,6 +58,11 @@ public class DuplicateLines extends AnAction {
 	@Override
 	public void update(AnActionEvent event) {
 		event.getPresentation().setEnabledAndVisible(event.getData(CommonDataKeys.EDITOR) != null);
+	}
+
+	@Override
+	public ActionUpdateThread getActionUpdateThread() {
+		return ActionUpdateThread.EDT;
 	}
 
 	/**


### PR DESCRIPTION
I've created an IDEA Plugin project based on https://github.com/JetBrains/intellij-platform-plugin-template template and I was able to compile, build (assemble) and test the plugin with this change - the warning is gone and the plugin is working.

I can happily use my local version, but it'd be nice to share the fix ;)

Is there a chance you publish version 1.0.2?
